### PR TITLE
feat: add new option update-description option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   jira-api-token:
     description: "Jira API token"
     required: true
+  update-description:
+    description: "Whether to update the PR description instead of adding a comment"
+    required: false
+    default: "false"
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -87393,6 +87393,7 @@ async function run() {
         const jiraBaseUrl = core.getInput("jira-base-url", { required: true });
         const jiraUsername = core.getInput("jira-username", { required: true });
         const jiraApiToken = core.getInput("jira-api-token", { required: true });
+        const updateDescription = core.getBooleanInput("update-description", { required: false }) || false;
         const octokit = github.getOctokit(githubToken);
         // Parse the Jira base URL to extract the host
         const jiraHost = new URL(jiraBaseUrl).hostname;
@@ -87430,36 +87431,60 @@ async function run() {
         // Get Jira issue details
         const issue = await jira.findIssue(jiraIssueKey);
         const issueUrl = `${jiraBaseUrl}/browse/${jiraIssueKey}`;
-        // Prepare the comment body with issue details
-        const commentBody = `
+        // Prepare the content with issue details
+        const jiraContent = `
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
     `.trim();
-        // Check for existing comment
-        const existingComments = await octokit.rest.issues.listComments({
-            ...github.context.repo,
-            issue_number: pull_request.number,
-        });
-        const existingComment = existingComments.data.find((comment) => comment.body?.includes(`Related Jira issue: [${jiraIssueKey}]`) ?? false);
-        if (existingComment) {
-            // Only update if the comment body is different
-            if (existingComment.body !== commentBody) {
-                await octokit.rest.issues.updateComment({
-                    ...github.context.repo,
-                    comment_id: existingComment.id,
-                    body: commentBody,
-                });
+        if (updateDescription) {
+            // Update PR description
+            const currentBody = pull_request.body || "";
+            const jiraSection = /Related Jira issue: \[[A-Z]+-\d+\].*$/m;
+            let newBody;
+            if (jiraSection.test(currentBody)) {
+                // Replace existing Jira section
+                newBody = currentBody.replace(jiraSection, jiraContent);
             }
             else {
-                core.info("Existing comment is up to date. No update needed.");
+                // Add Jira content at the end
+                newBody = currentBody
+                    ? `${currentBody}\n\n${jiraContent}`
+                    : jiraContent;
             }
+            await octokit.rest.pulls.update({
+                ...github.context.repo,
+                pull_number: pull_request.number,
+                body: newBody,
+            });
         }
         else {
-            // Create new comment
-            await octokit.rest.issues.createComment({
+            // Check for existing comment
+            const existingComments = await octokit.rest.issues.listComments({
                 ...github.context.repo,
                 issue_number: pull_request.number,
-                body: commentBody,
             });
+            const existingComment = existingComments.data.find((comment) => comment.body?.includes(`Related Jira issue: [${jiraIssueKey}]`) ??
+                false);
+            if (existingComment) {
+                // Only update if the comment body is different
+                if (existingComment.body !== jiraContent) {
+                    await octokit.rest.issues.updateComment({
+                        ...github.context.repo,
+                        comment_id: existingComment.id,
+                        body: jiraContent,
+                    });
+                }
+                else {
+                    core.info("Existing comment is up to date. No update needed.");
+                }
+            }
+            else {
+                // Create new comment
+                await octokit.rest.issues.createComment({
+                    ...github.context.repo,
+                    issue_number: pull_request.number,
+                    body: jiraContent,
+                });
+            }
         }
     }
     catch (error) {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -42,9 +42,13 @@ describe("Jira Issue Linker Action", () => {
         case "github-token":
           return "mock-token";
         case "jira-base-url":
-          return "mock-jira-url";
+          return "https://mock-jira-url";
+        case "jira-username":
+          return "mock-username";
         case "jira-api-token":
           return "mock-api-token";
+        case "update-description":
+          return "false";
         default:
           return "";
       }
@@ -53,10 +57,12 @@ describe("Jira Issue Linker Action", () => {
     mockOctokit = {
       rest: {
         pulls: {
-          update: jest.fn().mockResolvedValue({}),
+          update: jest.fn().mockResolvedValue({ data: {} }),
         },
         issues: {
-          createComment: jest.fn().mockResolvedValue({}),
+          createComment: jest.fn().mockResolvedValue({ data: {} }),
+          listComments: jest.fn().mockResolvedValue({ data: [] }),
+          updateComment: jest.fn().mockResolvedValue({ data: {} }),
         },
       },
     };
@@ -64,6 +70,7 @@ describe("Jira Issue Linker Action", () => {
 
     mockJiraClient = {
       findIssue: jest.fn().mockResolvedValue({
+        key: "TEST-123",
         fields: { summary: "Test Jira Issue" },
       }),
     } as unknown as jest.Mocked<JiraApi>;
@@ -96,7 +103,13 @@ describe("Jira Issue Linker Action", () => {
     await run();
 
     expect(mockOctokit.rest.pulls.update).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.issues.createComment).toHaveBeenCalled();
+    expect(mockOctokit.rest.issues.listComments).toHaveBeenCalled();
+    expect(mockOctokit.rest.issues.createComment).toHaveBeenCalledWith({
+      owner: "testowner",
+      repo: "testrepo",
+      issue_number: 1,
+      body: expect.stringContaining("TEST-123"),
+    });
   });
 
   it("should warn if no Jira issue key is found", async () => {
@@ -121,5 +134,146 @@ describe("Jira Issue Linker Action", () => {
     await run();
 
     expect(mockSetFailed).toHaveBeenCalledWith("Test error");
+  });
+
+  describe("when update-description is true", () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      const mockGetBooleanInput = core.getBooleanInput as jest.MockedFunction<
+        typeof core.getBooleanInput
+      >;
+      mockGetBooleanInput.mockReturnValue(true);
+
+      github.context.payload = {
+        pull_request: {
+          number: 1,
+          title: "Test PR",
+          head: { ref: "feature/TEST-123-new-feature" },
+        },
+      };
+
+      Object.defineProperty(github.context, "repo", {
+        value: { owner: "testowner", repo: "testrepo" },
+        configurable: true,
+      });
+
+      mockGetInput.mockImplementation((name) => {
+        switch (name) {
+          case "github-token":
+            return "mock-token";
+          case "jira-base-url":
+            return "https://mock-jira-url";
+          case "jira-username":
+            return "mock-username";
+          case "jira-api-token":
+            return "mock-api-token";
+          default:
+            return "";
+        }
+      });
+
+      mockOctokit = {
+        rest: {
+          pulls: {
+            update: jest.fn().mockResolvedValue({ data: {} }),
+          },
+          issues: {
+            createComment: jest.fn().mockResolvedValue({ data: {} }),
+            listComments: jest.fn().mockResolvedValue({ data: [] }),
+            updateComment: jest.fn().mockResolvedValue({ data: {} }),
+          },
+        },
+      };
+      mockGetOctokit.mockReturnValue(mockOctokit);
+
+      mockJiraClient = {
+        findIssue: jest.fn().mockResolvedValue({
+          key: "TEST-123",
+          fields: { summary: "Test Jira Issue" },
+        }),
+      } as unknown as jest.Mocked<JiraApi>;
+      (JiraApi as jest.MockedClass<typeof JiraApi>).mockImplementation(
+        () => mockJiraClient
+      );
+    });
+
+    it("should update PR description when no existing Jira section exists", async () => {
+      github.context.payload.pull_request!.title = "[TEST-123] Test PR";
+      github.context.payload.pull_request!.body = "Original description";
+
+      await run();
+
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: "testowner",
+        repo: "testrepo",
+        pull_number: 1,
+        body: expect.stringMatching(
+          /Original description\n\nRelated Jira issue: \[TEST-123\].*/
+        ),
+      });
+      expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it("should update existing Jira section in PR description", async () => {
+      github.context.payload.pull_request!.title = "[TEST-123] Test PR";
+      github.context.payload.pull_request!.body =
+        "Original description\n\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)";
+
+      await run();
+
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: "testowner",
+        repo: "testrepo",
+        pull_number: 1,
+        body: expect.stringMatching(
+          /Original description\n\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*/
+        ),
+      });
+      expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it("should create PR description if none exists", async () => {
+      github.context.payload.pull_request!.title = "[TEST-123] Test PR";
+      github.context.payload.pull_request!.body = "";
+
+      await run();
+
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: "testowner",
+        repo: "testrepo",
+        pull_number: 1,
+        body: expect.stringMatching(
+          /Related Jira issue: \[TEST-123\].*Test Jira Issue.*/
+        ),
+      });
+      expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it("should update both title and description when title needs updating", async () => {
+      github.context.payload.pull_request!.title = "Test PR";
+      github.context.payload.pull_request!.body = "Original description";
+
+      await run();
+
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(2);
+      expect(mockOctokit.rest.pulls.update).toHaveBeenNthCalledWith(1, {
+        owner: "testowner",
+        repo: "testrepo",
+        pull_number: 1,
+        title: "[TEST-123] Test PR",
+      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenNthCalledWith(2, {
+        owner: "testowner",
+        repo: "testrepo",
+        pull_number: 1,
+        body: expect.stringMatching(
+          /Original description\n\nRelated Jira issue: \[TEST-123\].*/
+        ),
+      });
+      expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,8 @@ export async function run() {
     const jiraBaseUrl = core.getInput("jira-base-url", { required: true });
     const jiraUsername = core.getInput("jira-username", { required: true });
     const jiraApiToken = core.getInput("jira-api-token", { required: true });
+    const updateDescription =
+      core.getBooleanInput("update-description", { required: false }) || false;
 
     const octokit = github.getOctokit(githubToken);
 
@@ -57,40 +59,64 @@ export async function run() {
     const issue = await jira.findIssue(jiraIssueKey);
     const issueUrl = `${jiraBaseUrl}/browse/${jiraIssueKey}`;
 
-    // Prepare the comment body with issue details
-    const commentBody = `
+    // Prepare the content with issue details
+    const jiraContent = `
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
     `.trim();
 
-    // Check for existing comment
-    const existingComments = await octokit.rest.issues.listComments({
-      ...github.context.repo,
-      issue_number: pull_request.number,
-    });
+    if (updateDescription) {
+      // Update PR description
+      const currentBody = pull_request.body || "";
+      const jiraSection = /Related Jira issue: \[[A-Z]+-\d+\].*$/m;
 
-    const existingComment = existingComments.data.find(
-      (comment) =>
-        comment.body?.includes(`Related Jira issue: [${jiraIssueKey}]`) ?? false
-    );
-
-    if (existingComment) {
-      // Only update if the comment body is different
-      if (existingComment.body !== commentBody) {
-        await octokit.rest.issues.updateComment({
-          ...github.context.repo,
-          comment_id: existingComment.id,
-          body: commentBody,
-        });
+      let newBody;
+      if (jiraSection.test(currentBody)) {
+        // Replace existing Jira section
+        newBody = currentBody.replace(jiraSection, jiraContent);
       } else {
-        core.info("Existing comment is up to date. No update needed.");
+        // Add Jira content at the end
+        newBody = currentBody
+          ? `${currentBody}\n\n${jiraContent}`
+          : jiraContent;
       }
+
+      await octokit.rest.pulls.update({
+        ...github.context.repo,
+        pull_number: pull_request.number,
+        body: newBody,
+      });
     } else {
-      // Create new comment
-      await octokit.rest.issues.createComment({
+      // Check for existing comment
+      const existingComments = await octokit.rest.issues.listComments({
         ...github.context.repo,
         issue_number: pull_request.number,
-        body: commentBody,
       });
+
+      const existingComment = existingComments.data.find(
+        (comment) =>
+          comment.body?.includes(`Related Jira issue: [${jiraIssueKey}]`) ??
+          false
+      );
+
+      if (existingComment) {
+        // Only update if the comment body is different
+        if (existingComment.body !== jiraContent) {
+          await octokit.rest.issues.updateComment({
+            ...github.context.repo,
+            comment_id: existingComment.id,
+            body: jiraContent,
+          });
+        } else {
+          core.info("Existing comment is up to date. No update needed.");
+        }
+      } else {
+        // Create new comment
+        await octokit.rest.issues.createComment({
+          ...github.context.repo,
+          issue_number: pull_request.number,
+          body: jiraContent,
+        });
+      }
     }
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
This PR adds the new `update-description` option. When this is enabled, the Github Action will modify the PRs description instead of adding a comment. This is useful for reducing bot noise on PRs.

I also fixed the broken tests