### PR TITLE
[REL-5968] Add unique identifier to fix duplicate message issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,3 +20,4 @@ jobs:
           jira-base-url: ${{ secrets.JIRA_BASE_URL }}
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+          update-description: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -87434,28 +87434,19 @@ async function run() {
         // Prepare the content with issue details
         const jiraContent = `
 <!-- ld-jira-link -->
+---
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
 <!-- end-ld-jira-link -->
     `.trim();
         if (updateDescription) {
             // Update PR description
             const currentBody = pull_request.body || "";
-            const jiraFooterRegex = /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/s;
-            // Format Jira content with footer separator
-            const formattedJiraContent = `\n\n---\n${jiraContent}`;
-            let newBody;
-            if (jiraFooterRegex.test(currentBody)) {
-                // Replace existing Jira footer, ensuring we don't duplicate the separator
-                newBody = currentBody.replace(jiraFooterRegex, formattedJiraContent);
-            }
-            else {
-                // Add Jira content as a footer
-                newBody = currentBody
-                    ? `${currentBody}${formattedJiraContent}`
-                    : jiraContent;
-            }
-            // Clean up any potential duplicate separators that might have accumulated
-            newBody = newBody.replace(/\n---\n---\n/g, "\n---\n");
+            // Remove all existing Jira sections first
+            const cleanBody = currentBody.replace(/\n*<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs, "");
+            // Add the new Jira content
+            const newBody = cleanBody
+                ? `${cleanBody.trim()}\n\n${jiraContent}`
+                : jiraContent;
             await octokit.rest.pulls.update({
                 ...github.context.repo,
                 pull_number: pull_request.number,

--- a/dist/index.js
+++ b/dist/index.js
@@ -87435,11 +87435,12 @@ async function run() {
         const jiraContent = `
 <!-- ld-jira-link -->
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
+<!-- end-ld-jira-link -->
     `.trim();
         if (updateDescription) {
             // Update PR description
             const currentBody = pull_request.body || "";
-            const jiraFooterRegex = /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*$/s;
+            const jiraFooterRegex = /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/s;
             // Format Jira content with footer separator
             const formattedJiraContent = `\n\n---\n${jiraContent}`;
             let newBody;

--- a/dist/index.js
+++ b/dist/index.js
@@ -87441,29 +87441,13 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
         if (updateDescription) {
             // Update PR description
             const currentBody = pull_request.body || "";
-            // First check if there's already a Jira section
-            const jiraPattern = /(?:\n\n)?<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs;
-            const hasJiraSection = jiraPattern.test(currentBody);
-            // Reset the regex lastIndex
-            jiraPattern.lastIndex = 0;
-            let newBody;
-            if (hasJiraSection) {
-                // Replace the first occurrence and remove any others
-                newBody = currentBody
-                    .replace(jiraPattern, (match, offset) => {
-                    // Only replace the first occurrence with our new content
-                    return offset === currentBody.indexOf(match)
-                        ? `\n\n${jiraContent}`
-                        : "";
-                })
-                    .trim();
-            }
-            else {
-                // Add new Jira content if none exists
-                newBody = currentBody
-                    ? `${currentBody.trim()}\n\n${jiraContent}`
-                    : jiraContent;
-            }
+            // Remove all existing Jira sections and clean up the content
+            const jiraPattern = /<!-- ld-jira-link -->[\s\S]*?<!-- end-ld-jira-link -->/g;
+            const cleanBody = currentBody.replace(jiraPattern, "").trim();
+            // Add the new Jira content
+            const newBody = cleanBody
+                ? `${cleanBody}\n\n${jiraContent}`
+                : jiraContent;
             await octokit.rest.pulls.update({
                 ...github.context.repo,
                 pull_number: pull_request.number,

--- a/dist/index.js
+++ b/dist/index.js
@@ -87441,12 +87441,29 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
         if (updateDescription) {
             // Update PR description
             const currentBody = pull_request.body || "";
-            // Remove all existing Jira sections first
-            const cleanBody = currentBody.replace(/\n*<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs, "");
-            // Add the new Jira content
-            const newBody = cleanBody
-                ? `${cleanBody.trim()}\n\n${jiraContent}`
-                : jiraContent;
+            // First check if there's already a Jira section
+            const jiraPattern = /(?:\n\n)?<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs;
+            const hasJiraSection = jiraPattern.test(currentBody);
+            // Reset the regex lastIndex
+            jiraPattern.lastIndex = 0;
+            let newBody;
+            if (hasJiraSection) {
+                // Replace the first occurrence and remove any others
+                newBody = currentBody
+                    .replace(jiraPattern, (match, offset) => {
+                    // Only replace the first occurrence with our new content
+                    return offset === currentBody.indexOf(match)
+                        ? `\n\n${jiraContent}`
+                        : "";
+                })
+                    .trim();
+            }
+            else {
+                // Add new Jira content if none exists
+                newBody = currentBody
+                    ? `${currentBody.trim()}\n\n${jiraContent}`
+                    : jiraContent;
+            }
             await octokit.rest.pulls.update({
                 ...github.context.repo,
                 pull_number: pull_request.number,

--- a/dist/index.js
+++ b/dist/index.js
@@ -87433,17 +87433,18 @@ async function run() {
         const issueUrl = `${jiraBaseUrl}/browse/${jiraIssueKey}`;
         // Prepare the content with issue details
         const jiraContent = `
+<!-- ld-jira-link -->
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
     `.trim();
         if (updateDescription) {
             // Update PR description
             const currentBody = pull_request.body || "";
-            const jiraFooterRegex = /\n---\nRelated Jira issue:.*$/s;
+            const jiraFooterRegex = /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*$/s;
             // Format Jira content with footer separator
             const formattedJiraContent = `\n\n---\n${jiraContent}`;
             let newBody;
             if (jiraFooterRegex.test(currentBody)) {
-                // Replace existing Jira footer
+                // Replace existing Jira footer, ensuring we don't duplicate the separator
                 newBody = currentBody.replace(jiraFooterRegex, formattedJiraContent);
             }
             else {
@@ -87452,6 +87453,8 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
                     ? `${currentBody}${formattedJiraContent}`
                     : jiraContent;
             }
+            // Clean up any potential duplicate separators that might have accumulated
+            newBody = newBody.replace(/\n---\n---\n/g, "\n---\n");
             await octokit.rest.pulls.update({
                 ...github.context.repo,
                 pull_number: pull_request.number,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -241,6 +241,33 @@ describe("Jira Issue Linker Action", () => {
 
       await run();
 
+      const expectedBody =
+        "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
+
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "testowner",
+          repo: "testrepo",
+          pull_number: 1,
+          body: expectedBody,
+        })
+      );
+
+      // Verify no duplicate sections exist in the result
+      const updateCall = mockOctokit.rest.pulls.update.mock.calls[0][0];
+      const occurrences = (
+        updateCall.body.match(/<!-- ld-jira-link -->/g) || []
+      ).length;
+      expect(occurrences).toBe(1);
+    });
+
+    it("should handle Jira section without preceding newlines", async () => {
+      github.context.payload.pull_request!.title = "[TEST-123] Test PR";
+      github.context.payload.pull_request!.body =
+        "Original description<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
+
+      await run();
+
       expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith(
         expect.objectContaining({
           owner: "testowner",
@@ -249,12 +276,6 @@ describe("Jira Issue Linker Action", () => {
           body: "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->",
         })
       );
-      // Verify no duplicate sections exist in the result
-      const updateCall = mockOctokit.rest.pulls.update.mock.calls[0][0];
-      const occurrences = (
-        updateCall.body.match(/<!-- ld-jira-link -->/g) || []
-      ).length;
-      expect(occurrences).toBe(1);
     });
 
     it("should create PR description if none exists", async () => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -218,7 +218,7 @@ describe("Jira Issue Linker Action", () => {
     it("should update existing Jira section in PR description", async () => {
       github.context.payload.pull_request!.title = "[TEST-123] Test PR";
       github.context.payload.pull_request!.body =
-        "Original description\n\n---\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)";
+        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)";
 
       await run();
 
@@ -228,10 +228,33 @@ describe("Jira Issue Linker Action", () => {
         repo: "testrepo",
         pull_number: 1,
         body: expect.stringMatching(
-          /Original description\n\n---\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*/
+          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*/
         ),
       });
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it("should handle multiple runs without creating duplicate sections", async () => {
+      github.context.payload.pull_request!.title = "[TEST-123] Test PR";
+      github.context.payload.pull_request!.body =
+        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)";
+
+      await run();
+
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: "testowner",
+        repo: "testrepo",
+        pull_number: 1,
+        body: expect.stringMatching(
+          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*/
+        ),
+      });
+      // Verify no duplicate sections exist in the result
+      const updateCall = mockOctokit.rest.pulls.update.mock.calls[0][0];
+      const occurrences = (
+        updateCall.body.match(/<!-- ld-jira-link -->/g) || []
+      ).length;
+      expect(occurrences).toBe(1);
     });
 
     it("should create PR description if none exists", async () => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -218,7 +218,7 @@ describe("Jira Issue Linker Action", () => {
     it("should update existing Jira section in PR description", async () => {
       github.context.payload.pull_request!.title = "[TEST-123] Test PR";
       github.context.payload.pull_request!.body =
-        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)";
+        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
 
       await run();
 
@@ -228,7 +228,7 @@ describe("Jira Issue Linker Action", () => {
         repo: "testrepo",
         pull_number: 1,
         body: expect.stringMatching(
-          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*/
+          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*<!-- end-ld-jira-link -->/
         ),
       });
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
@@ -237,7 +237,7 @@ describe("Jira Issue Linker Action", () => {
     it("should handle multiple runs without creating duplicate sections", async () => {
       github.context.payload.pull_request!.title = "[TEST-123] Test PR";
       github.context.payload.pull_request!.body =
-        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)";
+        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
 
       await run();
 
@@ -246,7 +246,7 @@ describe("Jira Issue Linker Action", () => {
         repo: "testrepo",
         pull_number: 1,
         body: expect.stringMatching(
-          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*/
+          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*<!-- end-ld-jira-link -->/
         ),
       });
       // Verify no duplicate sections exist in the result

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -204,51 +204,51 @@ describe("Jira Issue Linker Action", () => {
       await run();
 
       expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(1);
-      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
-        owner: "testowner",
-        repo: "testrepo",
-        pull_number: 1,
-        body: expect.stringMatching(
-          /Original description\n\n---\nRelated Jira issue: \[TEST-123\].*/
-        ),
-      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "testowner",
+          repo: "testrepo",
+          pull_number: 1,
+          body: "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->",
+        })
+      );
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
     });
 
     it("should update existing Jira section in PR description", async () => {
       github.context.payload.pull_request!.title = "[TEST-123] Test PR";
       github.context.payload.pull_request!.body =
-        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
+        "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
 
       await run();
 
       expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(1);
-      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
-        owner: "testowner",
-        repo: "testrepo",
-        pull_number: 1,
-        body: expect.stringMatching(
-          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*<!-- end-ld-jira-link -->/
-        ),
-      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "testowner",
+          repo: "testrepo",
+          pull_number: 1,
+          body: "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->",
+        })
+      );
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
     });
 
     it("should handle multiple runs without creating duplicate sections", async () => {
       github.context.payload.pull_request!.title = "[TEST-123] Test PR";
       github.context.payload.pull_request!.body =
-        "Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
+        "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Old summary](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->";
 
       await run();
 
-      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
-        owner: "testowner",
-        repo: "testrepo",
-        pull_number: 1,
-        body: expect.stringMatching(
-          /Original description\n\n---\n<!-- ld-jira-link -->\nRelated Jira issue: \[TEST-123\].*Test Jira Issue.*<!-- end-ld-jira-link -->/
-        ),
-      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "testowner",
+          repo: "testrepo",
+          pull_number: 1,
+          body: "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->",
+        })
+      );
       // Verify no duplicate sections exist in the result
       const updateCall = mockOctokit.rest.pulls.update.mock.calls[0][0];
       const occurrences = (
@@ -264,14 +264,14 @@ describe("Jira Issue Linker Action", () => {
       await run();
 
       expect(mockOctokit.rest.pulls.update).toHaveBeenCalledTimes(1);
-      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
-        owner: "testowner",
-        repo: "testrepo",
-        pull_number: 1,
-        body: expect.stringMatching(
-          /Related Jira issue: \[TEST-123\].*Test Jira Issue.*/
-        ),
-      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "testowner",
+          repo: "testrepo",
+          pull_number: 1,
+          body: "<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->",
+        })
+      );
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
     });
 
@@ -288,14 +288,15 @@ describe("Jira Issue Linker Action", () => {
         pull_number: 1,
         title: "[TEST-123] Test PR",
       });
-      expect(mockOctokit.rest.pulls.update).toHaveBeenNthCalledWith(2, {
-        owner: "testowner",
-        repo: "testrepo",
-        pull_number: 1,
-        body: expect.stringMatching(
-          /Original description\n\n---\nRelated Jira issue: \[TEST-123\].*/
-        ),
-      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          owner: "testowner",
+          repo: "testrepo",
+          pull_number: 1,
+          body: "Original description\n\n<!-- ld-jira-link -->\n---\nRelated Jira issue: [TEST-123]: [Test Jira Issue](https://mock-jira-url/browse/TEST-123)\n<!-- end-ld-jira-link -->",
+        })
+      );
       expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
     });
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,16 +70,32 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
     if (updateDescription) {
       // Update PR description
       const currentBody = pull_request.body || "";
-      // Remove all existing Jira sections first
-      const cleanBody = currentBody.replace(
-        /\n*<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs,
-        ""
-      );
 
-      // Add the new Jira content
-      const newBody = cleanBody
-        ? `${cleanBody.trim()}\n\n${jiraContent}`
-        : jiraContent;
+      // First check if there's already a Jira section
+      const jiraPattern =
+        /(?:\n\n)?<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs;
+      const hasJiraSection = jiraPattern.test(currentBody);
+
+      // Reset the regex lastIndex
+      jiraPattern.lastIndex = 0;
+
+      let newBody;
+      if (hasJiraSection) {
+        // Replace the first occurrence and remove any others
+        newBody = currentBody
+          .replace(jiraPattern, (match, offset) => {
+            // Only replace the first occurrence with our new content
+            return offset === currentBody.indexOf(match)
+              ? `\n\n${jiraContent}`
+              : "";
+          })
+          .trim();
+      } else {
+        // Add new Jira content if none exists
+        newBody = currentBody
+          ? `${currentBody.trim()}\n\n${jiraContent}`
+          : jiraContent;
+      }
 
       await octokit.rest.pulls.update({
         ...github.context.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,20 +61,22 @@ export async function run() {
 
     // Prepare the content with issue details
     const jiraContent = `
+<!-- ld-jira-link -->
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
     `.trim();
 
     if (updateDescription) {
       // Update PR description
       const currentBody = pull_request.body || "";
-      const jiraFooterRegex = /\n---\nRelated Jira issue:.*$/s;
+      const jiraFooterRegex =
+        /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*$/s;
 
       // Format Jira content with footer separator
       const formattedJiraContent = `\n\n---\n${jiraContent}`;
 
       let newBody;
       if (jiraFooterRegex.test(currentBody)) {
-        // Replace existing Jira footer
+        // Replace existing Jira footer, ensuring we don't duplicate the separator
         newBody = currentBody.replace(jiraFooterRegex, formattedJiraContent);
       } else {
         // Add Jira content as a footer
@@ -82,6 +84,9 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
           ? `${currentBody}${formattedJiraContent}`
           : jiraContent;
       }
+
+      // Clean up any potential duplicate separators that might have accumulated
+      newBody = newBody.replace(/\n---\n---\n/g, "\n---\n");
 
       await octokit.rest.pulls.update({
         ...github.context.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,13 +63,14 @@ export async function run() {
     const jiraContent = `
 <!-- ld-jira-link -->
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
+<!-- end-ld-jira-link -->
     `.trim();
 
     if (updateDescription) {
       // Update PR description
       const currentBody = pull_request.body || "";
       const jiraFooterRegex =
-        /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*$/s;
+        /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/s;
 
       // Format Jira content with footer separator
       const formattedJiraContent = `\n\n---\n${jiraContent}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,7 @@ export async function run() {
     // Prepare the content with issue details
     const jiraContent = `
 <!-- ld-jira-link -->
+---
 Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
 <!-- end-ld-jira-link -->
     `.trim();
@@ -69,25 +70,16 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
     if (updateDescription) {
       // Update PR description
       const currentBody = pull_request.body || "";
-      const jiraFooterRegex =
-        /\n*<!-- ld-jira-link -->\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/s;
+      // Remove all existing Jira sections first
+      const cleanBody = currentBody.replace(
+        /\n*<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs,
+        ""
+      );
 
-      // Format Jira content with footer separator
-      const formattedJiraContent = `\n\n---\n${jiraContent}`;
-
-      let newBody;
-      if (jiraFooterRegex.test(currentBody)) {
-        // Replace existing Jira footer, ensuring we don't duplicate the separator
-        newBody = currentBody.replace(jiraFooterRegex, formattedJiraContent);
-      } else {
-        // Add Jira content as a footer
-        newBody = currentBody
-          ? `${currentBody}${formattedJiraContent}`
-          : jiraContent;
-      }
-
-      // Clean up any potential duplicate separators that might have accumulated
-      newBody = newBody.replace(/\n---\n---\n/g, "\n---\n");
+      // Add the new Jira content
+      const newBody = cleanBody
+        ? `${cleanBody.trim()}\n\n${jiraContent}`
+        : jiraContent;
 
       await octokit.rest.pulls.update({
         ...github.context.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,31 +71,15 @@ Related Jira issue: [${jiraIssueKey}]: [${issue.fields.summary}](${issueUrl})
       // Update PR description
       const currentBody = pull_request.body || "";
 
-      // First check if there's already a Jira section
+      // Remove all existing Jira sections and clean up the content
       const jiraPattern =
-        /(?:\n\n)?<!-- ld-jira-link -->\n---\nRelated Jira issue:.*?<!-- end-ld-jira-link -->/gs;
-      const hasJiraSection = jiraPattern.test(currentBody);
+        /<!-- ld-jira-link -->[\s\S]*?<!-- end-ld-jira-link -->/g;
+      const cleanBody = currentBody.replace(jiraPattern, "").trim();
 
-      // Reset the regex lastIndex
-      jiraPattern.lastIndex = 0;
-
-      let newBody;
-      if (hasJiraSection) {
-        // Replace the first occurrence and remove any others
-        newBody = currentBody
-          .replace(jiraPattern, (match, offset) => {
-            // Only replace the first occurrence with our new content
-            return offset === currentBody.indexOf(match)
-              ? `\n\n${jiraContent}`
-              : "";
-          })
-          .trim();
-      } else {
-        // Add new Jira content if none exists
-        newBody = currentBody
-          ? `${currentBody.trim()}\n\n${jiraContent}`
-          : jiraContent;
-      }
+      // Add the new Jira content
+      const newBody = cleanBody
+        ? `${cleanBody}\n\n${jiraContent}`
+        : jiraContent;
 
       await octokit.rest.pulls.update({
         ...github.context.repo,


### PR DESCRIPTION
This PR updates the `update-description` logic to wrap the "Related Jira issue" message in a html comment block:
```html
<!-- ld-jira-link-x -->
---
Related Jira issue: ...
<!-- end-ld-jira-link-x -->
```

This allows us to use a multiline regex to strip any matches before adding the new one to ensure we never have duplicate messages.

<!-- ld-jira-link -->
---
Related Jira issue: [REL-5968]: [Update Jira Issue linker GHA so that it updates the PR description instead of adding a comment.](https://launchdarkly.atlassian.net/browse/REL-5968)
<!-- end-ld-jira-link -->